### PR TITLE
Use correct detection method for timeout errors

### DIFF
--- a/google/internal/externalaccount/executablecredsource.go
+++ b/google/internal/externalaccount/executablecredsource.go
@@ -89,7 +89,7 @@ var runCommand = func(ctx context.Context, command string, env []string) ([]byte
 		return response, nil
 	}
 
-	if ctx.Err() != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+	if ctx.Err() == context.DeadlineExceeded {
 		return nil, timeoutError()
 	}
 

--- a/google/internal/externalaccount/executablecredsource.go
+++ b/google/internal/externalaccount/executablecredsource.go
@@ -89,7 +89,7 @@ var runCommand = func(ctx context.Context, command string, env []string) ([]byte
 		return response, nil
 	}
 
-	if err == context.DeadlineExceeded {
+	if ctx.Err() != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return nil, timeoutError()
 	}
 


### PR DESCRIPTION
The previous method didn't work.  The error returned from cmd.Run() and cmd.Output are only ExitError with Exit Code 1.